### PR TITLE
Invfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ playbook which begins the device-specific tasks.
 
 Testing was conducted on the following platforms and versions:
   * Cisco CSR1000v, version 16.07.01a, running in AWS
+  * Cisco CSR1000v, version 16.09.02, running in AWS
+  * Cisco IOSv, version 15.6M, running in GNS3
   * Cisco XRv9000, version 6.3.1, running in AWS
   * Cisco 3172T, version 6.0.2.U6.4a, hardware appliance
 
@@ -161,6 +163,32 @@ as their main purpose is abstraction, not user input.__
   * `commands`: A list of strings representing the CLI commands to be
     issued to the device. These collect information from the devices relevant
     to troubleshooting OSPF.
+
+One special consideration is extended to `ios`. Because classic IOS and
+IOS-XE have minor differences in the commands they support, they use
+difference command lists. The IOS-related group variables are as follows:
+  * `ios`: General IOS parameters, applying to classic and XE variants
+  * `iosclassic`: Command list specific to classic IOS devices
+  * `iosxe`: Command list specific to IOS-XE devices
+
+An example inventory might look like this:
+
+```
+all:
+  children:
+    ospf_routers:
+      children:
+        ios:
+          children:
+            iosxe:
+              hosts:
+                CSR1000:
+                ISR4451:
+            iosclassic:
+              hosts:
+                C3945E:
+                C3750X:
+```
 
 Note that some extra commands are appended to the end of the `commands` list
 which are used for collection only. The output from these commands is written

--- a/devices/ios/main.yml
+++ b/devices/ios/main.yml
@@ -17,8 +17,13 @@
         OSPF_NBR: "{{ CLI_OUTPUT.stdout[1] | ios_ospf_neighbor }}"
         OSPF_DB: "{{ CLI_OUTPUT.stdout[2] | ios_ospf_dbsum }}"
         OSPF_TRAF: "{{ CLI_OUTPUT.stdout[3] | ios_ospf_traffic }}"
-        OSPF_FRR: "{{ CLI_OUTPUT.stdout[4] | ios_ospf_frr }}"
-        BFD_NBR: "{{ CLI_OUTPUT.stdout[5] | ios_bfd_neighbor }}"
+        BFD_NBR: "{{ CLI_OUTPUT.stdout[4] | ios_bfd_neighbor }}"
+
+    - name: "SYS >> Parse IOS-XE specific output into structured data"
+      set_fact:
+        OSPF_FRR: "{{ CLI_OUTPUT.stdout[5] | ios_ospf_frr }}"
+      when: "'iosxe' in group_names"
+
   when: "not ci_test"
 
 - name: "BLOCK >> Substitute mock CI variables of parsed data"

--- a/group_vars/ios.yml
+++ b/group_vars/ios.yml
@@ -1,15 +1,5 @@
 ---
 ansible_network_os: "ios"
-commands:
-  - "show ip ospf {{ process.id }}"
-  - "show ip ospf {{ process.id }} neighbor"
-  - "show ip ospf {{ process.id }} database database-summary"
-  - "show ip ospf {{ process.id }} traffic"
-  - "show ip ospf {{ process.id }} fast-reroute"
-  - "show bfd neighbor client ospf"
-  - "show ip ospf {{ process.id }} interface"  # not parsed
-  - "show ip ospf {{ process.id }} database"  # not parsed
-  - "show version"  # not parsed
 process:
   id: 1
   has_ispf: true

--- a/group_vars/iosclassic.yml
+++ b/group_vars/iosclassic.yml
@@ -1,0 +1,11 @@
+---
+commands:
+  - "show ip ospf {{ process.id }}"
+  - "show ip ospf {{ process.id }} neighbor"
+  - "show ip ospf {{ process.id }} database database-summary"
+  - "show ip ospf {{ process.id }} traffic"
+  - "show bfd neighbor client ospf"
+  - "show ip ospf {{ process.id }} interface"  # not parsed
+  - "show ip ospf {{ process.id }} database"  # not parsed
+  - "show version"  # not parsed
+...

--- a/group_vars/iosxe.yml
+++ b/group_vars/iosxe.yml
@@ -1,0 +1,12 @@
+---
+commands:
+  - "show ip ospf {{ process.id }}"
+  - "show ip ospf {{ process.id }} neighbor"
+  - "show ip ospf {{ process.id }} database database-summary"
+  - "show ip ospf {{ process.id }} traffic"
+  - "show bfd neighbor client ospf"
+  - "show ip ospf {{ process.id }} fast-reroute"  # IOS-XE specific
+  - "show ip ospf {{ process.id }} interface"  # not parsed
+  - "show ip ospf {{ process.id }} database"  # not parsed
+  - "show version"  # not parsed
+...

--- a/group_vars/ospf_routers.yml
+++ b/group_vars/ospf_routers.yml
@@ -1,5 +1,6 @@
 ---
 ci_test: false
+log: true
 ansible_user: "ansible"
 ansible_password: !vault |
           $ANSIBLE_VAULT;1.1;AES256

--- a/inv.yml
+++ b/inv.yml
@@ -2,18 +2,19 @@
 all:
   children:
     ospf_routers:
-      vars:
-        log: true
       children:
         ios:
-          hosts:
-            csr1:
-              my_areas: [0, 3, 4369]
-              my_nbr_count: 4
-            csr2:
-              my_areas: [2]
-              my_nbr_count: 1
-              should_be_stub_rtr: true
+          children:
+            iosxe:
+              hosts:
+                csr1:
+                  my_areas: [0, 3, 4369]
+                  my_nbr_count: 4
+                csr2:
+                  my_areas: [2]
+                  my_nbr_count: 1
+                  should_be_stub_rtr: true
+            iosclassic:
         iosxr:
           hosts:
             xrv1:

--- a/plugins/filter/filter.py
+++ b/plugins/filter/filter.py
@@ -179,9 +179,9 @@ class FilterModule(object):
             (?P<priority>\d+)\s+
             (?P<state>\w+)/\s*
             (?P<role>[A-Z-]+)\s+
-            (?P<uptime>[0-9:hdwy]+)\s+
+            (?P<uptime>[0-9:hdwy]+|-)\s+
             (?P<peer>\d+\.\d+\.\d+\.\d+)\s+
-            (?P<intf>[0-9A-Za-z./-]+)
+            (?P<intf>[0-9A-Za-z./_-]+)
         '''
         return FilterModule._ospf_neighbor(pattern, text, ['uptime'])
 
@@ -265,9 +265,9 @@ class FilterModule(object):
             (?P<priority>\d+)\s+
             (?P<state>\w+)/\s*
             (?P<role>[A-Z-]+)\s+
-            (?P<deadtime>[0-9:]+)\s+
+            (?P<deadtime>[0-9:]+|-)\s+
             (?P<peer>\d+\.\d+\.\d+\.\d+)\s+
-            (?P<intf>[0-9A-Za-z./-]+)
+            (?P<intf>[0-9A-Za-z./_-]+)
         '''
         return FilterModule._ospf_neighbor(pattern, text, ['deadtime'])
 
@@ -501,10 +501,10 @@ class FilterModule(object):
             (?P<priority>\d+)\s+
             (?P<state>\w+)/\s*
             (?P<role>[A-Z-]+)\s+
-            (?P<deadtime>[0-9:]+)\s+
+            (?P<deadtime>[0-9:]+|-)\s+
             (?P<peer>\d+\.\d+\.\d+\.\d+)\s+
             (?P<uptime>[0-9:hdwy]+)\s+
-            (?P<intf>[0-9A-Za-z./-]+)
+            (?P<intf>[0-9A-Za-z./_-]+)
         '''
         return FilterModule._ospf_neighbor(
             pattern, text, ['deadtime', 'uptime'])

--- a/plugins/filter/filter.py
+++ b/plugins/filter/filter.py
@@ -55,7 +55,7 @@ class FilterModule(object):
         elif key_filler_list:
             return_dict = {}
             for key in key_filler_list:
-                return_dict.update({key, None})
+                return_dict.update({key: None})
 
         return return_dict
 

--- a/tests/tasks/test_check_bfd_nbr.yml
+++ b/tests/tasks/test_check_bfd_nbr.yml
@@ -30,7 +30,7 @@
   assert:
     that: "bfd_nbrs | check_bfd_up(ospf_nbr)"
     msg: "not all OSPF neighbors showed up, check JSON above"
-  with_items: "{{ ospf_nbrs }}"
+  loop: "{{ ospf_nbrs }}"
   loop_control:
     loop_var: ospf_nbr
 ...

--- a/tests/tasks/test_ios_bfd_neighbor.yml
+++ b/tests/tasks/test_ios_bfd_neighbor.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOS BFD neighbor text"
   set_fact:
+    junk: "dummy text"
     text: |-
       IPv4 Sessions
       NeighAddr                LD/RD         RH/RS     State     Int
@@ -46,4 +47,15 @@
       - "data[2].rhrs == 'up'"
       - "data[2].state == 'down'"
       - "data[2].intf == 'gi0/1/2'"
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | ios_bfd_neighbor }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty list"
+  assert:
+    that: "empty | length == 0"
 ...

--- a/tests/tasks/test_ios_ospf_basic.yml
+++ b/tests/tasks/test_ios_ospf_basic.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOS OSPF basic text"
   set_fact:
+    junk: "dummy text"
     text: |-
       Routing Process "ospf 1" with ID 10.0.0.5
       Start time: 00:00:17.043, Time elapsed: 00:00:30.262
@@ -115,4 +116,23 @@
     that:
       - "data.areas[2].type == 'nssa'"
       - "data.areas[2].num_intfs == 4"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | ios_ospf_basic }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty structure"
+  assert:
+    that:
+      - "not empty.process.has_bfd"
+      - "not empty.process.has_ispf"
+      - "not empty.process.has_ttlsec"
+      - "not empty.process.is_abr"
+      - "not empty.process.is_asbr"
+      - "not empty.process.is_stub_rtr"
+      - "not empty.process.process"
 ...

--- a/tests/tasks/test_ios_ospf_dbsum.yml
+++ b/tests/tasks/test_ios_ospf_dbsum.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOS database summary text"
   set_fact:
+    junk: "dummy text"
     text: |-
       OSPF Router with ID (192.168.0.12) (Process ID 1)
 
@@ -77,4 +78,23 @@
       - "data.process.total_lsa4 == 44"
       - "data.process.total_lsa7 == 45"
       - "data.process.total_lsa5 == 48"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | ios_ospf_dbsum }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing failed at the process level"
+  assert:
+    that:
+      - "empty.areas | length == 0"
+      - "not empty.process.total_lsa1"
+      - "not empty.process.total_lsa2"
+      - "not empty.process.total_lsa3"
+      - "not empty.process.total_lsa4"
+      - "not empty.process.total_lsa5"
+      - "not empty.process.total_lsa7"
 ...

--- a/tests/tasks/test_ios_ospf_frr.yml
+++ b/tests/tasks/test_ios_ospf_frr.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOS OSPF FRR text"
   set_fact:
+    junk: "dummy text"
     text: |-
       OSPF Router with ID (10.0.0.2) (Process ID 1)
       Microloop avoidance is enabled for protected prefixes, delay 5000 msec
@@ -37,4 +38,16 @@
       - "not data.area51.tilfa"
       - "data.area51.topology == 'fun'"
     msg: "parsing problem. check JSON dump from previous task"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | ios_ospf_frr }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty dict"
+  assert:
+    that: "empty | length == 0"
 ...

--- a/tests/tasks/test_ios_ospf_neighbor.yml
+++ b/tests/tasks/test_ios_ospf_neighbor.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOS OSPF neighbor text"
   set_fact:
+    junk: "dummy text"
     text: |-
       Neighbor ID  Pri   State         Dead Time  Address        Interface
       10.108.23.50   0   FULL/  -      00:00:35   10.125.95.7    GigabitEth0/1
@@ -64,4 +65,16 @@
       - "data[3].deadtime_sec == 0"
       - "data[3].peer == '10.0.0.11'"
       - "data[3].intf == 'ospf_vl0'"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | ios_ospf_neighbor }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty list"
+  assert:
+    that: "empty | length == 0"
 ...

--- a/tests/tasks/test_ios_ospf_neighbor.yml
+++ b/tests/tasks/test_ios_ospf_neighbor.yml
@@ -6,6 +6,7 @@
       10.108.23.50   0   FULL/  -      00:00:35   10.125.95.7    GigabitEth0/1
       10.108.5.50  255   FULL/DR       00:00:34   10.125.95.137  Port-chan8.33
       10.255.6.50   23   2WAY/DROTHER  11:22:33   10.108.0.0     NVE8
+      10.0.0.11      0   FULL/  -        -        10.0.0.11      OSPF_VL0
 
 - name: "Perform parsing"
   set_fact:
@@ -18,7 +19,7 @@
 - name: "Ensure parsing succeeded for first neighbor"
   assert:
     that:
-      - "data | length == 3"
+      - "data | length == 4"
       - "data[0].rid == '10.108.23.50'"
       - "data[0].priority == 0"
       - "data[0].state == 'full'"
@@ -51,4 +52,16 @@
       - "data[2].deadtime_sec == 40953"
       - "data[2].peer == '10.108.0.0'"
       - "data[2].intf == 'nve8'"
+
+- name: "Ensure parsing succeeded for fourth neighbor (VL)"
+  assert:
+    that:
+      - "data[3].rid == '10.0.0.11'"
+      - "data[3].priority == 0"
+      - "data[3].state == 'full'"
+      - "data[3].role == '-'"
+      - "data[3].deadtime == '-'"
+      - "data[3].deadtime_sec == 0"
+      - "data[3].peer == '10.0.0.11'"
+      - "data[3].intf == 'ospf_vl0'"
 ...

--- a/tests/tasks/test_ios_ospf_traffic.yml
+++ b/tests/tasks/test_ios_ospf_traffic.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store OSPF traffic stats text"
   set_fact:
+    junk: "dummy text"
     text: |-
       Interface statistics
 
@@ -141,4 +142,16 @@
       - "data[1].unk_nbr == 16"
       - "data[1].version == 5"
     msg: "parsing problem; see JSON dump from previous task"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | ios_ospf_traffic }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty list"
+  assert:
+    that: "empty | length == 0"
 ...

--- a/tests/tasks/test_iosxr_ospf_basic.yml
+++ b/tests/tasks/test_iosxr_ospf_basic.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOSXR OSPF basic text"
   set_fact:
+    junk: "dummy text"
     text: |-
       Routing Process "ospf 42518" with ID 192.168.0.12
       Role: Primary Active
@@ -109,4 +110,20 @@
       - "data.areas[2].type == 'stub'"
       - "data.areas[2].num_intfs == 333"
       - "data.areas[2].frr_intfs == 33"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | iosxr_ospf_basic }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty structure"
+  assert:
+    that:
+      - "not empty.process.is_abr"
+      - "not empty.process.is_asbr"
+      - "not empty.process.is_stub_rtr"
+      - "not empty.process.process"
 ...

--- a/tests/tasks/test_iosxr_ospf_dbsum.yml
+++ b/tests/tasks/test_iosxr_ospf_dbsum.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOSXR database summary text"
   set_fact:
+    junk: "dummy text"
     text: |-
       OSPF Router with ID (192.168.0.12) (Process ID 1)
 
@@ -73,4 +74,23 @@
       - "data.process.total_lsa4 == 44"
       - "data.process.total_lsa7 == 45"
       - "data.process.total_lsa5 == 48"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | ios_ospf_dbsum }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing failed at the process level"
+  assert:
+    that:
+      - "empty.areas | length == 0"
+      - "not empty.process.total_lsa1"
+      - "not empty.process.total_lsa2"
+      - "not empty.process.total_lsa3"
+      - "not empty.process.total_lsa4"
+      - "not empty.process.total_lsa5"
+      - "not empty.process.total_lsa7"
 ...

--- a/tests/tasks/test_iosxr_ospf_neighbor.yml
+++ b/tests/tasks/test_iosxr_ospf_neighbor.yml
@@ -10,6 +10,7 @@
       Neighbor ID   Pri State    Dead Time Address       Up Time  Interface
       192.168.0.11  0   FULL/DR  00:00:32  192.168.1.11  1y1w4d2h Gi0/0/0/0.511
       192.168.0.12  1   FULL/ -  00:01:32  192.168.1.12  01:18:57 Gi1/2/3/4.512
+      10.10.10.10   1   FULL/ -      -     10.10.10.10   00:01:01 OSPF_VL0
 
       Area 51
       Neighbor ID   Pri State    Dead Time Address       Up Time  Interface
@@ -26,7 +27,7 @@
 - name: "Ensure parsing succeed for first neighbor"
   assert:
     that:
-      - "data | length == 3"
+      - "data | length == 4"
       - "data[0].rid == '192.168.0.11'"
       - "data[0].priority == 0"
       - "data[0].state == 'full'"
@@ -54,18 +55,34 @@
       - "data[1].intf | lower == 'gi1/2/3/4.512'"
     msg: "parsing problem. see JSON dump from previous task"
 
-- name: "Ensure parsing succeed for third neighbor"
+- name: "Ensure parsing succeed for third neighbor (VL)"
   assert:
     that:
-      - "data[2].rid == '192.168.0.13'"
-      - "data[2].priority == 255"
-      - "data[2].state == 'init'"
+      - "data[2].rid == '10.10.10.10'"
+      - "data[2].priority == 1"
+      - "data[2].state == 'full'"
       - "data[2].role == '-'"
-      - "data[2].deadtime == '00:02:32'"
-      - "data[2].deadtime_sec == 152"
-      - "data[2].peer == '192.168.1.13'"
-      - "data[2].uptime == '02:18:57'"
-      - "data[2].uptime_sec == 8337"
-      - "data[2].intf | lower == 'tunnel-ip13'"
+      - "data[2].deadtime == '-'"
+      - "data[2].deadtime_sec == 0"
+      - "data[2].peer == '10.10.10.10'"
+      - "data[2].uptime == '00:01:01'"
+      - "data[2].uptime_sec == 61"
+      - "data[2].intf | lower == 'ospf_vl0'"
     msg: "parsing problem. see JSON dump from previous task"
+
+- name: "Ensure parsing succeed for fourth neighbor"
+  assert:
+    that:
+      - "data[3].rid == '192.168.0.13'"
+      - "data[3].priority == 255"
+      - "data[3].state == 'init'"
+      - "data[3].role == '-'"
+      - "data[3].deadtime == '00:02:32'"
+      - "data[3].deadtime_sec == 152"
+      - "data[3].peer == '192.168.1.13'"
+      - "data[3].uptime == '02:18:57'"
+      - "data[3].uptime_sec == 8337"
+      - "data[3].intf | lower == 'tunnel-ip13'"
+    msg: "parsing problem. see JSON dump from previous task"
+
 ...

--- a/tests/tasks/test_iosxr_ospf_neighbor.yml
+++ b/tests/tasks/test_iosxr_ospf_neighbor.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOSXR OSPF neighbor text"
   set_fact:
+    junk: "dummy text"
     text: |-
       * Indicates MADJ interface
 
@@ -85,4 +86,15 @@
       - "data[3].intf | lower == 'tunnel-ip13'"
     msg: "parsing problem. see JSON dump from previous task"
 
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | iosxr_ospf_neighbor }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty list"
+  assert:
+    that: "empty | length == 0"
 ...

--- a/tests/tasks/test_iosxr_ospf_traffic.yml
+++ b/tests/tasks/test_iosxr_ospf_traffic.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store IOSXR OSPF traffic stats text"
   set_fact:
+    junk: "dummy text"
     text: |-
       Interface GigabitEthernet0/0/0/0.511 Process ID 1 Area 0
 
@@ -141,4 +142,16 @@
       - "data[1].enq_rtr == 27"
       - "data[1].unspec_tx == 28"
     msg: "parsing failed; see JSON dump from previous task"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | iosxr_ospf_traffic }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty list"
+  assert:
+    that: "empty | length == 0"
 ...

--- a/tests/tasks/test_nxos_ospf_basic.yml
+++ b/tests/tasks/test_nxos_ospf_basic.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store NXOS OSPF basic text"
   set_fact:
+    junk: "dummy text"
     text: |-
        Routing Process 1 with ID 10.0.0.3 VRF default
        Routing Process Instance Number 2
@@ -88,4 +89,21 @@
       - "data.areas[1].id == 4369"
       - "data.areas[1].type == 'stub'"
       - "data.areas[1].num_intfs == 17"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | nxos_ospf_basic }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty structure"
+  assert:
+    that:
+      - "empty.areas | length == 0"
+      - "not empty.process.is_abr"
+      - "not empty.process.is_asbr"
+      - "not empty.process.is_stub_rtr"
+      - "not empty.process.process"
 ...

--- a/tests/tasks/test_nxos_ospf_dbsum.yml
+++ b/tests/tasks/test_nxos_ospf_dbsum.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store NXOS database summary text"
   set_fact:
+    junk: "dummy text"
     text: |-
       OSPF Router with ID (10.0.0.3) (Process ID 1 VRF default)
 
@@ -75,4 +76,23 @@
       - "data.process.total_lsa4 == 444"
       - "data.process.total_lsa7 == 777"
       - "data.process.total_lsa5 == 555"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | nxos_ospf_dbsum }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing failed at the process level"
+  assert:
+    that:
+      - "empty.areas | length == 0"
+      - "not empty.process.total_lsa1"
+      - "not empty.process.total_lsa2"
+      - "not empty.process.total_lsa3"
+      - "not empty.process.total_lsa4"
+      - "not empty.process.total_lsa5"
+      - "not empty.process.total_lsa7"
 ...

--- a/tests/tasks/test_nxos_ospf_neighbor.yml
+++ b/tests/tasks/test_nxos_ospf_neighbor.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store NXOS OSPF neighbor text"
   set_fact:
+    junk: "dummy text"
     text: |-
       OSPF Process ID 1 VRF default
       Total number of neighbors: 2
@@ -56,4 +57,16 @@
       - "data[2].peer == '4.2.5.18'"
       - "data[2].intf == 'vl0'"
     msg: "parsing problem. see JSON dump from previous task"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | nxos_ospf_neighbor }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty list"
+  assert:
+    that: "empty | length == 0"
 ...

--- a/tests/tasks/test_nxos_ospf_neighbor.yml
+++ b/tests/tasks/test_nxos_ospf_neighbor.yml
@@ -7,6 +7,7 @@
       Neighbor ID     Pri State      Up Time  Address       Interface
       2.2.2.2           1 FULL/ -    1y2w3d4h 192.168.0.2   Eth1/43
       2.255.2.0       255 2WAY/BDR   21:01:05 10.192.17.6   Port-Cha1
+      4.2.5.18          0 FULL/ -    00:01:05 4.2.5.18      VL0
 
 - name: "Perform parsing"
   set_fact:
@@ -19,7 +20,7 @@
 - name: "Ensure parsing succeeded for first neighbor"
   assert:
     that:
-      - "data | length == 2"
+      - "data | length == 3"
       - "data[0].rid == '2.2.2.2'"
       - "data[0].priority == 1"
       - "data[0].state == 'full'"
@@ -28,6 +29,7 @@
       - "data[0].uptime_sec == 0"  # issue #1
       - "data[0].peer == '192.168.0.2'"
       - "data[0].intf == 'eth1/43'"
+    msg: "parsing problem. see JSON dump from previous task"
 
 - name: "Ensure parsing succeeded for second neighbor"
   assert:
@@ -40,4 +42,18 @@
       - "data[1].uptime_sec == 75665"
       - "data[1].peer == '10.192.17.6'"
       - "data[1].intf == 'port-cha1'"
+    msg: "parsing problem. see JSON dump from previous task"
+
+- name: "Ensure parsing succeeded for third neighbor (VL)"
+  assert:
+    that:
+      - "data[2].rid == '4.2.5.18'"
+      - "data[2].priority == 0"
+      - "data[2].state == 'full'"
+      - "data[2].role == '-'"
+      - "data[2].uptime == '00:01:05'"
+      - "data[2].uptime_sec == 65"
+      - "data[2].peer == '4.2.5.18'"
+      - "data[2].intf == 'vl0'"
+    msg: "parsing problem. see JSON dump from previous task"
 ...

--- a/tests/tasks/test_nxos_ospf_traffic.yml
+++ b/tests/tasks/test_nxos_ospf_traffic.yml
@@ -1,6 +1,7 @@
 ---
 - name: "Store NXOS OSPF traffic stats text"
   set_fact:
+    junk: "dummy text"
     text: |-
       OSPF Process ID 65535 VRF default, Packet Counters (cleared 00:26:37 ago)
       Total: 184 in, 343 out
@@ -60,4 +61,16 @@
       - "data[0].bad_auth == 27"
       - "data[0].no_vrf == 28"
     msg: "parsing failed; see JSON dump from previous task"
+
+- name: "Perform parsing of junk input"
+  set_fact:
+    empty: "{{ junk | nxos_ospf_traffic }}"
+
+- name: "Print empty data"
+  debug:
+    var: empty
+
+- name: "Ensure parsing results in an empty list"
+  assert:
+    that: "empty | length == 0"
 ...


### PR DESCRIPTION
General fixes:

  - Works on classic IOS by not trying to check FRR on those devices (not supported)
  - `iosclassic` and `iosxe` inventory groups and different `commands` lists
  - better unit testing, to include negative testing. bug fixes in some parsers
  - updated README and Makefile